### PR TITLE
Add Zensical-based docs, README badges, and GitHub Actions workflow for docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,55 @@
+name: Documentation
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "zensical.toml"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yaml"
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - "docs/**"
+      - "zensical.toml"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yaml"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install zensical
+      - run: zensical build --clean
+
+  deploy:
+    if: github.event_name == 'push'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/configure-pages@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install zensical
+      - run: zensical build --clean
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 
 # Mastering Python Project Management with UV: MLOps
 
+[![Docs Build](https://img.shields.io/github/actions/workflow/status/OWNER/mlops-uv/docs.yaml?label=docs&branch=main)](https://github.com/OWNER/mlops-uv/actions/workflows/docs.yaml)
+[![Published Docs](https://img.shields.io/badge/docs-github%20pages-blue)](https://OWNER.github.io/mlops-uv/)
+
+> ℹ️ Replace `OWNER` in the badge and docs links with your GitHub username or organization.
+
 ## How to use
 
 You have two options to follow along with this guide:
@@ -224,3 +229,10 @@ With **AceBet**, we demonstrated how to:
 **Give UV a try**—it might just **replace Pip and Poetry** in your workflow! 🚀  
 
 **Happy Coding!**
+
+
+## Documentation
+
+- Local docs guide: [`docs/getting-started.md`](docs/getting-started.md)
+- Local preview command: `zensical serve`
+- Docs contribution flow: update Markdown in `docs/`, run `zensical build --clean`, preview with `zensical serve`, then open a PR.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,51 @@
+# Getting Started
+
+This project uses **Zensical** to build and preview documentation from Markdown files under `docs/`.
+
+## Prerequisites
+
+- Python 3.10+
+- [uv](https://docs.astral.sh/uv/)
+
+## Install tooling
+
+Run these commands from the repository root:
+
+```bash
+uv sync --dev
+uv add --dev zensical
+```
+
+## Bootstrap docs (if needed)
+
+```bash
+zensical new .
+```
+
+## Build docs locally
+
+```bash
+zensical build --clean
+```
+
+## Preview docs locally
+
+```bash
+zensical serve
+```
+
+## Contribution flow for docs updates
+
+1. Create a branch for your documentation update.
+2. Add or edit Markdown files in `docs/`.
+3. Run a local docs build:
+   ```bash
+   zensical build --clean
+   ```
+4. Run local preview and validate rendering:
+   ```bash
+   zensical serve
+   ```
+5. Commit your changes and open a pull request.
+
+On pull requests, GitHub Actions builds docs automatically. On pushes to `main`, docs are published to GitHub Pages.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# AceBet Documentation
+
+Welcome to the AceBet project documentation.
+
+- Start here: [Getting Started](./getting-started.md)

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -1,0 +1,5 @@
+# Markdown Guide
+
+This page exists as part of the default Zensical scaffold.
+
+Use it to document project-specific Markdown conventions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ package-data = {"*" = ["**/*.joblib", "**/*.feather"]}
 
 
 [project.optional-dependencies]
+docs = [
+    "zensical",
+]
+
 test = [
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,19 @@
+[project]
+site_name = "Documentation"
+site_url = "https://OWNER.github.io/mlops-uv/"
+
+[build]
+source = "docs"
+output = "site"
+
+[[nav]]
+title = "Home"
+path = "index.md"
+
+[[nav]]
+title = "Getting Started"
+path = "getting-started.md"
+
+[[nav]]
+title = "Markdown"
+path = "markdown.md"

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "Documentation"
-site_url = "https://OWNER.github.io/mlops-uv/"
+site_url = "https://OWNER.github.io/mlops-uv/" # ℹ️ Replace OWNER with your GitHub username or organization.
 
 [build]
 source = "docs"


### PR DESCRIPTION
### Motivation

- Provide a simple documentation site for the project using Zensical and make docs editable under `docs/`.
- Automate docs building on pull requests and publishing to GitHub Pages on push via a GitHub Actions workflow.
- Make it easy for contributors to preview and build docs locally and ensure docs tooling is tracked in project metadata.

### Description

- Added a new GitHub Actions workflow at `.github/workflows/docs.yaml` that runs `zensical build --clean` on pull requests and builds + deploys site to GitHub Pages on pushes to `main`/`master`.
- Added Zensical site configuration in `zensical.toml` and a small docs scaffold under `docs/` including `index.md`, `getting-started.md`, and `markdown.md` with local build/serve instructions.
- Updated `README.md` with docs badges and a short docs contribution guide, and added an optional `docs` dependency (`zensical`) to `pyproject.toml`.

### Testing

- No automated tests were executed as part of this change; the new CI job `build` in `docs.yaml` is configured to run `zensical build --clean` on pull requests and the `deploy` job runs on push to publish via GitHub Pages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a48e0a3be48329b27f660dc8bc489d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated documentation build and deploy pipeline for the project
  * Local docs build and preview commands for contributors

* **Documentation**
  * Added Getting Started guide and Markdown conventions reference
  * Added site index, navigation, and build status / published docs badges

* **Chores**
  * Added docs build configuration and an optional docs dependency for local/site builds
<!-- end of auto-generated comment: release notes by coderabbit.ai -->