### PR TITLE
Add .env onboarding flow and ignore local dotenv variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,9 @@ celerybeat-schedule
 
 # Environments
 .env
+.env.local
+.env.*.local
+!.env.example
 .venv
 env/
 venv/

--- a/README.md
+++ b/README.md
@@ -5,12 +5,23 @@ AceBet is a FastAPI-based MLOps sample project that demonstrates how to use UV f
 ## Quickstart
 
 ```bash
+cp .env.example .env
+# set ACEBET_SECRET_KEY to a strong generated value in .env
 uv sync
 uv run pytest tests
 uv run fastapi run src/acebet/app/main.py --host 0.0.0.0 --port 8000
 ```
 
+Generate a strong key (pick one):
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(64))"
+# or
+openssl rand -hex 64
+```
+
 Expected quickstart result:
+- Environment file exists at `.env` and contains a strong `ACEBET_SECRET_KEY`.
 - Dependencies install successfully.
 - Test suite passes.
 - API starts locally and responds at `http://localhost:8000`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,19 +18,35 @@ git clone https://github.com/OWNER/REPOSITORY.git mlops-uv
 cd mlops-uv
 ```
 
-### 2. Install dependencies
+### 2. Create local environment config
+
+```bash
+cp .env.example .env
+```
+
+Set `ACEBET_SECRET_KEY` in `.env` to a strong generated value.
+
+Generate a strong key (pick one):
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(64))"
+# or
+openssl rand -hex 64
+```
+
+### 3. Install dependencies
 
 ```bash
 uv sync
 ```
 
-### 3. Run tests
+### 4. Run tests
 
 ```bash
 uv run pytest tests
 ```
 
-### 4. Start the API
+### 5. Start the API
 
 ```bash
 uv run fastapi run src/acebet/app/main.py --host 0.0.0.0 --port 8000
@@ -38,6 +54,7 @@ uv run fastapi run src/acebet/app/main.py --host 0.0.0.0 --port 8000
 
 ## Expected output
 
+- `.env` exists (copied from `.env.example`) and includes a strong `ACEBET_SECRET_KEY`.
 - `uv sync` completes with a success message and creates/updates `.venv`.
 - `uv run pytest tests` shows all tests passing.
 - `uv run fastapi run ...` shows a running server and a local URL such as `http://0.0.0.0:8000`.


### PR DESCRIPTION
### Motivation
- Prevent accidental commits of local secrets by ignoring common dotenv variants while keeping an example environment file tracked. 
- Make the first step of local setup explicit so users create a `.env` and populate required secrets before running the project. 
- Provide simple, practical one-liner examples for generating a strong `ACEBET_SECRET_KEY` so onboarding is actionable.

### Description
- Updated `.gitignore` to add ` .env.local` and `.env.*.local` and explicitly un-ignore `!.env.example` so example config remains in the repo while local env files are ignored. 
- Updated `README.md` `Quickstart` to include `cp .env.example .env`, a reminder to set `ACEBET_SECRET_KEY`, and one-liner generation examples using `python -c "import secrets; print(secrets.token_urlsafe(64))"` and `openssl rand -hex 64`. 
- Updated `docs/getting-started.md` to insert the same configuration-first flow and key-generation one-liners before dependency installation and test/run steps. 

### Testing
- Ran the test suite with `uv run pytest tests` and the automated tests completed successfully (`4 passed`) with warnings only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a57f2253f48329bba4daaea4c92e93)