### PR TITLE
Refactor configuration usage, improve Dockerfile, and add startup validation & logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,28 @@
 FROM python:3.12-slim
 
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
 # Install uv.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# Copy the application into the container.
-COPY . /app
-
-# Install the application dependencies.
 WORKDIR /app
+
+# Copy dependency manifests first for better layer caching.
+COPY pyproject.toml uv.lock ./
+
+# Install project dependencies (without installing the project itself yet).
+RUN uv sync --frozen --no-cache --no-install-project
+
+# Copy application source.
+COPY src ./src
+
+# Install the local project into the existing virtual environment.
 RUN uv sync --frozen --no-cache
+
+# Use an unprivileged user at runtime.
+RUN addgroup --system app && adduser --system --ingroup app app && chown -R app:app /app
+USER app
 
 # Run the application.
 CMD ["/app/.venv/bin/fastapi", "run", "src/acebet/app/main.py", "--port", "80", "--host", "0.0.0.0"]
-
-
-

--- a/src/acebet/app/config.py
+++ b/src/acebet/app/config.py
@@ -1,5 +1,7 @@
 """Application configuration loaded and validated from environment variables."""
 
+from typing import Any
+
 from pydantic import Field, ValidationError, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -11,9 +13,17 @@ class AppSettings(BaseSettings):
 
     model_config = SettingsConfigDict(extra="ignore")
 
-    acebet_env: str = Field(alias="ACEBET_ENV")
+    acebet_env: str = Field(default="development", alias="ACEBET_ENV")
     acebet_secret_key: str | None = Field(default=None, alias="ACEBET_SECRET_KEY")
     acebet_jwt_algorithm: str = Field(default="HS256", alias="ACEBET_JWT_ALGORITHM")
+    acebet_log_level: str = Field(default="INFO", alias="ACEBET_LOG_LEVEL")
+    acebet_log_file: str | None = Field(default=None, alias="ACEBET_LOG_FILE")
+    acebet_default_rate_limit: str = Field(
+        default="100/minute", alias="ACEBET_DEFAULT_RATE_LIMIT"
+    )
+    acebet_login_rate_limit: str = Field(
+        default="5/minute", alias="ACEBET_LOGIN_RATE_LIMIT"
+    )
     acebet_access_token_expire_minutes: int = Field(
         default=30,
         alias="ACEBET_ACCESS_TOKEN_EXPIRE_MINUTES",
@@ -24,7 +34,9 @@ class AppSettings(BaseSettings):
     def validate_expiry_minutes(cls, value: int) -> int:
         """Ensure token expiration minutes is a positive integer."""
         if value <= 0:
-            raise ValueError("ACEBET_ACCESS_TOKEN_EXPIRE_MINUTES must be greater than 0.")
+            raise ValueError(
+                "ACEBET_ACCESS_TOKEN_EXPIRE_MINUTES must be greater than 0."
+            )
         return value
 
     @model_validator(mode="after")
@@ -38,12 +50,15 @@ class AppSettings(BaseSettings):
             )
         return self
 
+    def redacted(self) -> dict[str, Any]:
+        """Return a safe settings representation for structured logging."""
+        payload = self.model_dump()
+        if payload.get("acebet_secret_key"):
+            payload["acebet_secret_key"] = "***REDACTED***"
+        return payload
+
 
 settings = AppSettings()
-
-ACEBET_SECRET_KEY = settings.acebet_secret_key or "acebet-dev-insecure-secret-key"
-ACEBET_JWT_ALGORITHM = settings.acebet_jwt_algorithm
-ACEBET_ACCESS_TOKEN_EXPIRE_MINUTES = settings.acebet_access_token_expire_minutes
 
 
 def validate_config() -> None:

--- a/src/acebet/app/dependencies/auth.py
+++ b/src/acebet/app/dependencies/auth.py
@@ -1,7 +1,7 @@
 """Authentication and authorization helpers for the FastAPI application."""
 
-from datetime import datetime, timedelta
 import os
+from datetime import datetime, timedelta
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, Request, status
@@ -9,17 +9,11 @@ from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 
-from acebet.app.config import (
-    ACEBET_ACCESS_TOKEN_EXPIRE_MINUTES,
-    ACEBET_JWT_ALGORITHM,
-    ACEBET_SECRET_KEY,
-)
+from acebet.app.config import settings
 
 from .data_models import TokenData, UserInDB
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
-ACCESS_TOKEN_EXPIRE_MINUTES = ACEBET_ACCESS_TOKEN_EXPIRE_MINUTES
-
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
@@ -126,7 +120,11 @@ def create_access_token(data: dict, expires_delta: timedelta | None = None) -> s
     else:
         expire = datetime.utcnow() + timedelta(minutes=15)
     to_encode.update({"exp": expire})
-    encoded_jwt = jwt.encode(to_encode, ACEBET_SECRET_KEY, algorithm=ACEBET_JWT_ALGORITHM)
+    encoded_jwt = jwt.encode(
+        to_encode,
+        settings.acebet_secret_key or "acebet-dev-insecure-secret-key",
+        algorithm=settings.acebet_jwt_algorithm,
+    )
     return encoded_jwt
 
 
@@ -148,7 +146,11 @@ def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]) -> UserInDB:
         headers={"WWW-Authenticate": "Bearer"},
     )
     try:
-        payload = jwt.decode(token, ACEBET_SECRET_KEY, algorithms=[ACEBET_JWT_ALGORITHM])
+        payload = jwt.decode(
+            token,
+            settings.acebet_secret_key or "acebet-dev-insecure-secret-key",
+            algorithms=[settings.acebet_jwt_algorithm],
+        )
         username: str | None = payload.get("sub")
         if username is None:
             raise credentials_exception

--- a/src/acebet/app/main.py
+++ b/src/acebet/app/main.py
@@ -1,6 +1,7 @@
 """FastAPI application entrypoint and route handlers."""
 
 import logging
+from contextlib import asynccontextmanager
 from datetime import timedelta
 from pathlib import Path
 
@@ -13,9 +14,8 @@ from slowapi.util import get_remote_address
 from starlette.background import BackgroundTask
 from starlette.types import Message
 
-from acebet.app.config import validate_config
+from acebet.app.config import settings, validate_config
 from acebet.app.dependencies.auth import (
-    ACCESS_TOKEN_EXPIRE_MINUTES,
     authenticate_user,
     create_access_token,
     fake_users_db,
@@ -33,24 +33,25 @@ from acebet.app.dependencies.predict_winner import make_prediction
 
 limiter = Limiter(
     key_func=get_remote_address,
-    default_limits=[settings.default_rate_limit],
+    default_limits=[settings.acebet_default_rate_limit],
 )
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    """Run startup validations before serving requests."""
+    validate_config()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 logging.basicConfig(
-    filename=settings.log_file,
-    level=getattr(logging, settings.log_level.upper(), logging.DEBUG),
+    filename=settings.acebet_log_file,
+    level=getattr(logging, settings.acebet_log_level.upper(), logging.DEBUG),
 )
 logger = logging.getLogger(__name__)
 logger.debug("Effective config (secrets redacted): %s", settings.redacted())
-
-
-@app.on_event("startup")
-def validate_startup_config() -> None:
-    """Validate required runtime configuration before serving requests."""
-    validate_config()
-
 
 def log_info(req_body: bytes, res_body: bytes) -> None:
     """Write request and response payloads to the configured logger.
@@ -113,7 +114,7 @@ def home() -> dict[str, str]:
 
 
 @app.get("/limit/")
-@limiter.limit(settings.login_rate_limit)
+@limiter.limit(settings.acebet_login_rate_limit)
 def limit(request: Request, user_id: str) -> dict[str, str]:
     """Return a response for a rate-limited demonstration endpoint.
 
@@ -149,7 +150,9 @@ def login_for_access_token(
             detail="Incorrect username or password",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token_expires = timedelta(
+        minutes=settings.acebet_access_token_expire_minutes
+    )
     access_token = create_access_token(
         data={"sub": user.username}, expires_delta=access_token_expires
     )


### PR DESCRIPTION
### Motivation
- Centralize and extend runtime configuration to support logging, rate limits, and safe secret handling. 
- Harden the container image for better build caching, deterministic dependency install, and non-root runtime. 
- Validate configuration early at startup and use the settings consistently across auth, rate limiting, and logging.

### Description
- Updated `Dockerfile` to set `PYTHONDONTWRITEBYTECODE`/`PYTHONUNBUFFERED`, copy `pyproject.toml` and `uv.lock` first for layer caching, perform a two-stage `uv sync` to avoid installing the project twice, copy `src` afterwards, and add an unprivileged `app` user to run the image. 
- Expanded `AppSettings` in `src/acebet/app/config.py` with defaults for `acebet_env`, logging fields, and rate limits, added a `redacted()` helper to hide `acebet_secret_key`, and kept `validate_config()` to raise a clear `RuntimeError` on invalid settings. 
- Changed authentication in `src/acebet/app/dependencies/auth.py` to use the new `settings` object for JWT encoding/decoding and removed previous module-level constants, while preserving a development fallback secret. 
- Modified `src/acebet/app/main.py` to use an async `lifespan` that calls `validate_config()` at startup, wire `Limiter` defaults from `settings`, switch logging to `settings.acebet_log_file` and `settings.acebet_log_level`, and use `settings.acebet_access_token_expire_minutes` for token expiry. 

### Testing
- Ran `pytest` and unit tests completed successfully. 
- Built the Docker image with `docker build .` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6d769926483299188e9f04ed4978c)