### PR TITLE
Follow-up: include runtime data directory in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ COPY pyproject.toml uv.lock ./
 # Install project dependencies (without installing the project itself yet).
 RUN uv sync --frozen --no-cache --no-install-project
 
-# Copy application source.
+# Copy application source and runtime data assets.
 COPY src ./src
+COPY data ./data
 
 # Install the local project into the existing virtual environment.
 RUN uv sync --frozen --no-cache


### PR DESCRIPTION
### Motivation
- The Dockerfile refactor removed copying the top-level `data/` tree which caused the `/predict` endpoint (which reads `/app/data/atp_data_production.feather` in non-testing mode) to fail at runtime with missing data files.

### Description
- Add `COPY data ./data` to `Dockerfile` so runtime data assets are present under `/app/data`, while keeping the dependency-manifests-first layering (manifests → deps → source/data) to preserve build cache behavior.

### Testing
- Inspected the updated `Dockerfile` with `nl -ba Dockerfile | sed -n '1,80p'` and confirmed the new `COPY data ./data` line; the inspection succeeded.
- Queried Dockerfile reference with `curl -s https://docs.docker.com/reference/dockerfile/ | head -n 20` for context; the call succeeded.
- Verified repository state and commit with `git status --short` and `git rev-parse HEAD` to ensure the change was committed (commit `9dabf11`); both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6e41297588329b8dae0bdbabf11f8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build process to include runtime data assets in the containerized application. The deployment configuration now copies necessary data files alongside application source code, ensuring all required runtime data is available when the application is deployed. This improves the reliability of the container image by including all required assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->