### PR TITLE
Dockerfile: add multi-stage build, pin uv, improve caching and runtime user handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,52 @@
-FROM python:3.12-slim
+# syntax=docker/dockerfile:1.4
+
+FROM python:3.12.10-slim AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-# Install uv.
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Pin uv to a specific version for reproducible builds.
+COPY --from=ghcr.io/astral-sh/uv:0.5.26 /uv /uvx /bin/
 
 WORKDIR /app
 
-# Copy dependency manifests first for better layer caching.
+# Copy only what uv needs to resolve dependencies.
+# README.md and LICENSE are intentionally excluded here to avoid
+# invalidating the dependency cache on every doc edit.
 COPY pyproject.toml uv.lock ./
 
-# Install project dependencies (without installing the project itself yet).
+# Install dependencies without installing the local project yet.
+# This layer is cached as long as pyproject.toml and uv.lock don't change.
 RUN uv sync --frozen --no-cache --no-install-project
 
-# Copy application source and runtime data assets.
+# Copy source and data only after dependencies are cached.
 COPY src ./src
 COPY data ./data
 
 # Install the local project into the existing virtual environment.
 RUN uv sync --frozen --no-cache
 
-# Use an unprivileged user at runtime.
-RUN addgroup --system app && adduser --system --ingroup app app && chown -R app:app /app
+
+FROM python:3.12.10-slim AS runtime
+
+# Activate the venv globally so python/fastapi are on PATH without hardcoding.
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/app/.venv/bin:$PATH"
+
+WORKDIR /app
+
+# Create unprivileged user before copying files so we can chown in one pass.
+RUN addgroup --system app && adduser --system --ingroup app app
+
+# Copy only runtime artifacts from builder, owned by app from the start.
+# This avoids a separate chown -R pass (which creates an extra layer).
+COPY --from=builder --chown=app:app /app/.venv /app/.venv
+COPY --from=builder --chown=app:app /app/src  /app/src
+COPY --from=builder --chown=app:app /app/data /app/data
+
 USER app
 
-# Run the application.
-CMD ["/app/.venv/bin/fastapi", "run", "src/acebet/app/main.py", "--port", "80", "--host", "0.0.0.0"]
+EXPOSE 80
+
+CMD ["fastapi", "run", "src/acebet/app/main.py", "--port", "80", "--host", "0.0.0.0"]


### PR DESCRIPTION
### Motivation

- Improve build reproducibility and layer caching for faster iterative builds.
- Reduce final image size and remove unnecessary layers by splitting build/runtime concerns.
- Ensure the runtime container runs as an unprivileged user and avoids extra `chown` passes.

### Description

- Add Docker build syntax directive and convert to a multi-stage build with `FROM python:3.12.10-slim AS builder` and a separate `runtime` stage. 
- Pin `uv` to `ghcr.io/astral-sh/uv:0.5.26` and copy only the dependency manifests `pyproject.toml` and `uv.lock` to maximize layer cache effectiveness. 
- Use `uv sync --frozen --no-cache --no-install-project` to install dependencies first, then copy source and data and run `uv sync --frozen --no-cache` to install the local project. 
- Create an unprivileged `app` user in the runtime stage and copy runtime artifacts from the builder with `--chown=app:app` to avoid an extra `chown -R` layer, set `PATH="/app/.venv/bin:$PATH"`, add `EXPOSE 80`, and run the app via the `fastapi` binary on `PATH`.

### Testing

- Built the runtime image with `docker build --target runtime -t acebet:pr .` and the build completed successfully. 
- Ran a quick automated runtime check with `docker run --rm acebet:pr fastapi --help` and the `fastapi` binary executed successfully, confirming the virtualenv is on `PATH`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6e65ff3048329b302d79edc4d934d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container build configuration for faster deployment and enhanced security practices, including optimized dependency caching and unprivileged runtime execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->